### PR TITLE
Make `install` script prefer pre-built binaries on macOS too

### DIFF
--- a/install
+++ b/install
@@ -6,18 +6,7 @@ set -o nounset
 UNAME="$(uname)"
 ARCH="$(uname -m)"
 
-if [ "$UNAME" = "Darwin" ]
-then
-  if [ "$ARCH" != "arm64" ]
-  then
-    echo "ERROR: There are no pre-built JSON Schema CLI binaries for macOS on $ARCH" 1>&2
-    echo "You might be able to build it from source" 1>&2
-    exit 1
-  fi
-
-  echo "---- Attempting to install the JSON Schema CLI using Homebrew" 1>&2
-  brew install intelligence-ai/apps/jsonschema
-elif [ "$UNAME" = "Linux" ]
+if [ "$UNAME" = "Darwin" ] || [ "$UNAME" = "Linux" ]
 then
   echo "---- Fetching the pre-built JSON Schema CLI binary from GitHub Releases" 1>&2
   OWNER="intelligence-ai"
@@ -31,7 +20,7 @@ then
   TMP="$(mktemp -d)"
   clean() { rm -rf "$TMP"; }
   trap clean EXIT
-  curl --location --output "$TMP/artifact.zip" "$PACKAGE_URL" 
+  curl --location --output "$TMP/artifact.zip" "$PACKAGE_URL"
   unzip "$TMP/artifact.zip" -d "$TMP/out"
   mkdir -p "$OUTPUT/bin"
   install -v -m 0755 "$TMP/out/jsonschema-$LATEST_TAG-$PACKAGE_PLATFORM_NAME-$ARCH/bin/jsonschema" "$OUTPUT/bin"


### PR DESCRIPTION
For version selection

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
