### PR TITLE
Fix `test` and `validate` obsolete Draft 4 warnings

### DIFF
--- a/docs/test.markdown
+++ b/docs/test.markdown
@@ -2,8 +2,9 @@ Testing
 =======
 
 > [!WARNING]
-> Only JSON Schema Draft 4 is supported at this point in time. We have plans
-> to support *every* dialect of JSON Schema from Draft 0 to Draft 2020-12 soon.
+> Only JSON Schema Draft 4, Draft 6, and Draft 7 are supported at this point in
+> time. We have plans to support *every* dialect of JSON Schema from Draft 0 to
+> Draft 2020-12 soon.
 
 ```sh
 jsonschema test [schemas-or-directories...]

--- a/docs/validate.markdown
+++ b/docs/validate.markdown
@@ -2,8 +2,9 @@ Validating
 ==========
 
 > [!WARNING]
-> Only JSON Schema Draft 4 is supported at this point in time. We have plans
-> to support *every* dialect of JSON Schema from Draft 0 to Draft 2020-12 soon.
+> Only JSON Schema Draft 4, Draft 6, and Draft 7 are supported at this point in
+> time. We have plans to support *every* dialect of JSON Schema from Draft 0 to
+> Draft 2020-12 soon.
 
 ```sh
 jsonschema validate <schema.json>


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
