### PR TITLE
Fix crash when using a nested `propertyNames` in Draft 6 and Draft 7

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,4 +1,4 @@
 vendorpull https://github.com/sourcemeta/vendorpull dea311b5bfb53b6926a4140267959ae334d3ecf4
 noa https://github.com/sourcemeta/noa 2bc3138b80e575786bec418c91fc2058c6836993
-jsontoolkit https://github.com/sourcemeta/jsontoolkit 573808a8e7f615a05d1afeaae83dade50eeac920
+jsontoolkit https://github.com/sourcemeta/jsontoolkit bcb37abed9a93b97aa590ea5af2740ebfd246ab2
 hydra https://github.com/sourcemeta/hydra 3c53d3fdef79e9ba603d48470a508cc45472a0dc

--- a/vendor/jsontoolkit/src/jsonschema/default_compiler_draft6.h
+++ b/vendor/jsontoolkit/src/jsonschema/default_compiler_draft6.h
@@ -161,7 +161,7 @@ auto compiler_draft6_applicator_contains(const SchemaCompilerContext &context)
       // TODO: As an optimization, avoid this condition if the subschema
       // declares `type` to `array` already
       {make<SchemaCompilerAssertionTypeStrict>(
-          context, JSON::Type::Array, {},
+          applicate(context), JSON::Type::Array, {},
           SchemaCompilerTargetType::Instance)})};
 }
 
@@ -175,7 +175,7 @@ auto compiler_draft6_validation_propertynames(
       // TODO: As an optimization, avoid this condition if the subschema
       // declares `type` to `object` already
       {make<SchemaCompilerAssertionTypeStrict>(
-          context, JSON::Type::Object, {},
+          applicate(context), JSON::Type::Object, {},
           SchemaCompilerTargetType::Instance)})};
 }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
