### PR TITLE
Do not print valid intermediate errors on `validate` on success

### DIFF
--- a/src/command_test.cc
+++ b/src/command_test.cc
@@ -47,13 +47,15 @@ auto intelligence::jsonschema::cli::test(
           sourcemeta::jsontoolkit::metaschema(schema.value(), test_resolver),
           sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
           sourcemeta::jsontoolkit::default_schema_compiler)};
+      std::ostringstream error;
       if (sourcemeta::jsontoolkit::evaluate(
               metaschema_template, schema.value(),
               sourcemeta::jsontoolkit::SchemaCompilerEvaluationMode::Fast,
-              pretty_evaluate_callback)) {
+              pretty_evaluate_callback(error))) {
         log_verbose(options)
             << "The schema is valid with respect to its metaschema\n";
       } else {
+        std::cerr << error.str();
         std::cerr << "The schema is NOT valid with respect to its metaschema\n";
         return EXIT_FAILURE;
       }

--- a/src/command_validate.cc
+++ b/src/command_validate.cc
@@ -28,14 +28,18 @@ auto intelligence::jsonschema::cli::validate(
         sourcemeta::jsontoolkit::metaschema(schema, custom_resolver),
         sourcemeta::jsontoolkit::default_schema_walker, custom_resolver,
         sourcemeta::jsontoolkit::default_schema_compiler)};
+    std::ostringstream error;
     if (sourcemeta::jsontoolkit::evaluate(
             metaschema_template, schema,
             sourcemeta::jsontoolkit::SchemaCompilerEvaluationMode::Fast,
-            pretty_evaluate_callback)) {
+            pretty_evaluate_callback(error))) {
       log_verbose(options)
-          << "The schema is valid with respect to its metaschema\n";
+          << schema_path
+          << ": The schema is valid with respect to its metaschema\n";
     } else {
-      std::cerr << "The schema is NOT valid with respect to its metaschema\n";
+      std::cerr << error.str();
+      std::cerr << schema_path
+                << ": The schema is NOT valid with respect to its metaschema\n";
       return EXIT_FAILURE;
     }
   }
@@ -49,13 +53,16 @@ auto intelligence::jsonschema::cli::validate(
 
     const auto instance{sourcemeta::jsontoolkit::from_file(instance_path)};
 
+    std::ostringstream error;
     result = sourcemeta::jsontoolkit::evaluate(
         schema_template, instance,
         sourcemeta::jsontoolkit::SchemaCompilerEvaluationMode::Fast,
-        pretty_evaluate_callback);
+        pretty_evaluate_callback(error));
 
     if (result) {
       log_verbose(options) << "Valid\n";
+    } else {
+      std::cerr << error.str();
     }
   }
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -130,25 +130,29 @@ auto parse_options(const std::span<const std::string> &arguments,
   return options;
 }
 
-auto pretty_evaluate_callback(
-    bool result,
-    const sourcemeta::jsontoolkit::SchemaCompilerTemplate::value_type &step,
-    const sourcemeta::jsontoolkit::Pointer &evaluate_path,
-    const sourcemeta::jsontoolkit::Pointer &instance_location,
-    const sourcemeta::jsontoolkit::JSON &,
-    const sourcemeta::jsontoolkit::JSON &) -> void {
-  if (result) {
-    return;
-  }
+auto pretty_evaluate_callback(std::ostringstream &output)
+    -> sourcemeta::jsontoolkit::SchemaCompilerEvaluationCallback {
+  return [&output](
+             bool result,
+             const sourcemeta::jsontoolkit::SchemaCompilerTemplate::value_type
+                 &step,
+             const sourcemeta::jsontoolkit::Pointer &evaluate_path,
+             const sourcemeta::jsontoolkit::Pointer &instance_location,
+             const sourcemeta::jsontoolkit::JSON &,
+             const sourcemeta::jsontoolkit::JSON &) -> void {
+    if (result) {
+      return;
+    }
 
-  std::cerr << "error: " << sourcemeta::jsontoolkit::describe(step) << "\n";
-  std::cerr << "    at instance location \"";
-  sourcemeta::jsontoolkit::stringify(instance_location, std::cerr);
-  std::cerr << "\"\n";
+    output << "error: " << sourcemeta::jsontoolkit::describe(step) << "\n";
+    output << "    at instance location \"";
+    sourcemeta::jsontoolkit::stringify(instance_location, output);
+    output << "\"\n";
 
-  std::cerr << "    at evaluate path \"";
-  sourcemeta::jsontoolkit::stringify(evaluate_path, std::cerr);
-  std::cerr << "\"\n";
+    output << "    at evaluate path \"";
+    sourcemeta::jsontoolkit::stringify(evaluate_path, output);
+    output << "\"\n";
+  };
 }
 
 static auto fallback_resolver(

--- a/src/utils.h
+++ b/src/utils.h
@@ -10,6 +10,7 @@
 #include <ostream>    // std::ostream
 #include <set>        // std::set
 #include <span>       // std::span
+#include <sstream>    // std::ostringstream
 #include <string>     // std::string
 #include <utility>    // std::pair
 #include <vector>     // std::vector
@@ -31,13 +32,8 @@ auto for_each_json(const std::vector<std::string> &arguments,
     -> std::vector<
         std::pair<std::filesystem::path, sourcemeta::jsontoolkit::JSON>>;
 
-auto pretty_evaluate_callback(
-    bool result,
-    const sourcemeta::jsontoolkit::SchemaCompilerTemplate::value_type &,
-    const sourcemeta::jsontoolkit::Pointer &evaluate_path,
-    const sourcemeta::jsontoolkit::Pointer &instance_location,
-    const sourcemeta::jsontoolkit::JSON &,
-    const sourcemeta::jsontoolkit::JSON &) -> void;
+auto pretty_evaluate_callback(std::ostringstream &)
+    -> sourcemeta::jsontoolkit::SchemaCompilerEvaluationCallback;
 
 auto resolver(const std::map<std::string, std::vector<std::string>> &options,
               const bool remote = false)


### PR DESCRIPTION
See: https://github.com/asyncapi/spec-json-schemas/pull/549
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
