### PR TITLE
Fix docs for `validate` to omit meta-schema validation

### DIFF
--- a/docs/validate.markdown
+++ b/docs/validate.markdown
@@ -7,14 +7,14 @@ Validating
 > Draft 2020-12 soon.
 
 ```sh
-jsonschema validate <schema.json> [instance.json] [--http/-h] [--verbose/-v]
+jsonschema validate <schema.json> <instance.json> [--http/-h] [--verbose/-v]
   [--resolve/-r <schemas-or-directories> ...]
 ```
 
 The most popular use case of JSON Schema is to validate JSON documents. The
 JSON Schema CLI offers a `validate` command to evaluate a JSON instance against
-a JSON Schema or a JSON Schema against its meta-schema, presenting
-human-friendly information on unsuccessful validation.
+a JSON Schema, presenting human-friendly information on unsuccessful
+validation.
 
 **If you want to validate that a schema adheres to its metaschema, use the
 [`metaschema`](./metaschema.markdown) command instead.**

--- a/src/main.cc
+++ b/src/main.cc
@@ -23,12 +23,10 @@ Global Options:
 
 Commands:
 
-   validate <schema.json> [instance.json] [--http/-h]
+   validate <schema.json> <instance.json> [--http/-h]
 
-       If an instance is passed, validate it against the given schema.
-       Otherwise, validate the schema against its dialect metaschema. The
-       `--http/-h` option enables resolving remote schemas over the HTTP
-       protocol.
+       Validate an instance against the given schema. The `--http/-h` option
+       enables resolving remote schemas over the HTTP protocol.
 
    metaschema [schemas-or-directories...] [--http/-h]
               [--extension/-e <extension>]


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
